### PR TITLE
Possibly fix the crash + support PWA and all other icons

### DIFF
--- a/Tweak/Koi.h
+++ b/Tweak/Koi.h
@@ -20,14 +20,24 @@ NSString* alphaValue = @"0.5";
 - (void)_forceTouchControllerWillPresent:(id)arg1;
 @end
 
+@interface SBIconImageView : UIView
+- (UIImage *)displayedImage;
+@end
+
+@interface SBIcon
+- (NSString *)applicationBundleID;
+@end
+
 @interface SBIconView : UIView
 - (id)_iconImageView;
 - (id)folder;
+- (SBIcon *)icon;
 - (void)activateShortcut:(id)item withBundleIdentifier:(NSString*)bundleID forIconView:(id)iconView;
+- (SBIconImageView *)currentImageView;
 @end
 
 @interface SBFolder : NSObject
--(NSArray *)icons;
+-(NSArray<SBIcon *> *)icons;
 @end
 
 @interface UIImage (Koi)

--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: 0xcc.woodfairy.koi
 Name: Koi 🐠
 Depends: mobilesubstrate, preferenceloader, ws.hbang.common (>= 1.14), firmware (>= 13.0), love.litten.libkitten
-Version: 1.0
+Version: 1.1
 Architecture: iphoneos-arm
 Description: Colorize the force touch menu background based on the app icon color
 Maintainer: woodfairy & Litten <hiya@litten.love>


### PR DESCRIPTION
I don't really have a way to test if it 100% works, as I don't have libKitten. But it doesn't crash for sure now (when I held on a PWA icon), as I've tested it with a placeholder color.