### PR TITLE
More improvements

### DIFF
--- a/Tweak/Koi.h
+++ b/Tweak/Koi.h
@@ -15,6 +15,9 @@ NSString* alphaValue = @"0.5";
 - (id)dismissalHandler;
 @end
 
+@interface _UIContextMenuActionsListView : UIView
+@end
+
 @interface SBIconController : UIViewController
 - (id)containerViewForPresentingContextMenuForIconView:(id)iconView;
 - (void)_forceTouchControllerWillPresent:(id)arg1;

--- a/Tweak/Tweak.x
+++ b/Tweak/Tweak.x
@@ -7,23 +7,27 @@ UIColor *currentBundleColor = nil;
 
 
 %group Koi
+/*
+%hook _UIContextMenuActionsListView
 
+- (void)willMoveToWindow:(UIWindow *)newWindow {
+	[[([self.subviews objectAtIndex:0]).subviews objectAtIndex:0] setBackgroundColor:currentBundleColor];
+	%orig;
+}
+%end
+*/
 %hook _UIContextMenuContainerView
 
 - (id)init {
-
 	contextMenuContainerView = self;
 	return %orig;
-
 }
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
-
 	[UIView animateWithDuration:1.0 animations:^{
 		[self setBackgroundColor:currentBundleColor];
 	} completion:NULL];
 	%orig;
-
 }
 
 %end
@@ -32,7 +36,6 @@ UIColor *currentBundleColor = nil;
 %hook SBIconController
 
 - (id)containerViewForPresentingContextMenuForIconView:(SBIconView *)iconView {
-
 	SBFolder *folder = [iconView folder];
 	NSString *bundleIdentifier;
 
@@ -51,8 +54,12 @@ UIColor *currentBundleColor = nil;
 	} else {
 		// alternatively fall back to currently displayed low-res icon image if there is no bundle
 		SBIconImageView *view = [iconView currentImageView];
-		if (view)
-			image = [view displayedImage];
+		if (view) {
+			if ([image respondsToSelector:@selector(displayedImage)]) {
+				image = [view displayedImage];
+			}
+			
+		}
 	}
 
 	if (!image)
@@ -60,6 +67,8 @@ UIColor *currentBundleColor = nil;
 
 	currentBundleColor =
 		[[nena secondaryColor:image] colorWithAlphaComponent:[alphaValue doubleValue]];
+
+	NSLog(@"currentBundleColor %@", currentBundleColor);
 	
 	return %orig;
 

--- a/Tweak/Tweak.x
+++ b/Tweak/Tweak.x
@@ -11,7 +11,8 @@ UIColor *currentBundleColor = nil;
 %hook _UIContextMenuActionsListView
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
-	[[([self.subviews objectAtIndex:0]).subviews objectAtIndex:0] setBackgroundColor:currentBundleColor];
+	if ([self.subviews count] && [self.subviews objectAtIndex:0] && [([self.subviews objectAtIndex:0]).subviews count])
+		[[([self.subviews objectAtIndex:0]).subviews objectAtIndex:0] setBackgroundColor:currentBundleColor];
 	%orig;
 }
 %end
@@ -80,8 +81,6 @@ UIColor *currentBundleColor = nil;
 
 	currentBundleColor =
 		[[nena secondaryColor:image] colorWithAlphaComponent:[alphaValue doubleValue]];
-
-	NSLog(@"currentBundleColor %@", currentBundleColor);
 	
 	return %orig;
 

--- a/Tweak/Tweak.x
+++ b/Tweak/Tweak.x
@@ -55,7 +55,7 @@ UIColor *currentBundleColor = nil;
 		// alternatively fall back to currently displayed low-res icon image if there is no bundle
 		SBIconImageView *view = [iconView currentImageView];
 		if (view) {
-			if ([image respondsToSelector:@selector(displayedImage)]) {
+			if ([view respondsToSelector:@selector(displayedImage)]) {
 				image = [view displayedImage];
 			}
 			

--- a/layout/DEBIAN/postinst
+++ b/layout/DEBIAN/postinst
@@ -1,3 +1,3 @@
 echo ""
-echo "Thank You For Installing Koi 1.0 🤗"
+echo "Thank You for installing Koi 1.0 🤗"
 echo ""


### PR DESCRIPTION
* clears the previous color and adds a check, so the previous color is not used if new one cannot be found
* added fallback method to grab a color from iOS 14 widgets
* turned the code into 3 clearly separated fallback methods, hopefully that's more readable :D 
* tries to first read the cached displayedImage from memory, before falling back to reading the image from bundle, it does feel faster on an older device for me

Pardon the first 3 commits that are already here, I did a rebase merge first and apparently GitHub didn't like it for PR-ing lol